### PR TITLE
Feat/custom mappings f29 34

### DIFF
--- a/sites/mosul/configs/openfn/version.txt
+++ b/sites/mosul/configs/openfn/version.txt
@@ -1,0 +1,15 @@
+Changes included in this version:
+- Support for custom logic for forms F29-MHPSS Baseline v2, F30-MHPSS Follow-up v2, F31-mhGAP Baseline v2, F32-mhGAP Follow-up v2, F33-MHPSS Closure v2, F34-mhGAP Closure v2
+- WF1 and WF2 are using LIME EMR - Iraq Metadata - Release 1 - v2025-06-05.xls metadata file
+
+This YAML addresses the following github issues: 
+https://github.com/OpenFn/msf-lime-mosul/issues/103
+https://github.com/OpenFn/msf-lime-mosul/issues/104
+https://github.com/OpenFn/msf-lime-mosul/issues/105
+https://github.com/OpenFn/msf-lime-mosul/issues/112
+https://github.com/OpenFn/msf-lime-mosul/issues/119
+
+Supported OMRS Versions:
+- F29-MHPSS Baseline v2, F30-MHPSS Follow-up v2, F31-mhGAP Baseline v2, F32-mhGAP Follow-up v2, F33-MHPSS Closure v2, F34-mhGAP Closure v2, F00-Registration, F01-MHPSS Baseline, F02-MHPSS Follow-up, F03-mhGAP Baseline, F04-mhGAP Follow-up, F05-MHPSS Closure and F06-mhGAP Closure
+
+Yaml version: v1.2.0


### PR DESCRIPTION
## Summary
### Changes included in this version:
- Support for custom logic for forms F29-MHPSS Baseline v2, F30-MHPSS Follow-up v2, F31-mhGAP Baseline v2, F32-mhGAP Follow-up v2, F33-MHPSS Closure v2, F34-mhGAP Closure v2
- WF1 and WF2 are using LIME EMR - Iraq Metadata - Release 1 - v2025-06-05.xls metadata file

### Supported OMRS Versions:
- F29-MHPSS Baseline v2, F30-MHPSS Follow-up v2, F31-mhGAP Baseline v2, F32-mhGAP Follow-up v2, F33-MHPSS Closure v2, F34-mhGAP Closure v2, F00-Registration, F01-MHPSS Baseline, F02-MHPSS Follow-up, F03-mhGAP Baseline, F04-mhGAP Follow-up, F05-MHPSS Closure and F06-mhGAP Closure

**Yaml version: v1.2.0**

## Related Issue
https://github.com/OpenFn/msf-lime-mosul/issues/103
https://github.com/OpenFn/msf-lime-mosul/issues/104
https://github.com/OpenFn/msf-lime-mosul/issues/105
https://github.com/OpenFn/msf-lime-mosul/issues/112
https://github.com/OpenFn/msf-lime-mosul/issues/119
